### PR TITLE
Update content.xwiki2

### DIFF
--- a/src/xwiki/RTFrontend/GetKey/content.xwiki2
+++ b/src/xwiki/RTFrontend/GetKey/content.xwiki2
@@ -1,4 +1,4 @@
-{{velocity}}
+{{velocity wiki="false"}}
 #if ($xcontext.action == "get")
     #set ($editorData = "$!request.getParameter('data')")
     #if ($editorData == "")


### PR DESCRIPTION
make the output in json format forcefully. 
double backslashes are regarded as a line break without the attribute.

https://jira.xwiki.org/projects/RTWYSIWYG/issues/RTWYSIWYG-74
